### PR TITLE
The concept of full exporter has been implemented as snack explorer

### DIFF
--- a/helpers/__tests__/snack-explorer.test.js
+++ b/helpers/__tests__/snack-explorer.test.js
@@ -1,0 +1,141 @@
+import { fs, vol } from 'memfs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { listAllSnacks } from '../snack-explorer';
+
+vi.mock('fs/promises', () => {
+    return {
+        default: fs.promises
+    }
+});
+
+let consoleLogSpy;
+
+describe('snackExplorer', () => {
+
+    beforeEach(() => {
+        vol.reset();
+        consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should list all easy snacks (3)', async () => {
+
+        vol.fromJSON(
+            {
+                [`${process.cwd()}/snacks/easy/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-2/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-2/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-2/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-3/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-3/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-3/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/medium/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/medium/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/medium/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+            }
+        );
+        vol.mkdirSync(process.cwd(), { recursive: true });
+        await listAllSnacks('easy');
+
+        expect(consoleLogSpy).toHaveBeenCalledTimes(3);
+        expect(consoleLogSpy).toHaveBeenCalledWith('snack-1');
+        expect(consoleLogSpy).toHaveBeenCalledWith('snack-2');
+        expect(consoleLogSpy).toHaveBeenCalledWith('snack-3');
+    });
+
+    it('should list all medium snacks (1)', async () => {
+
+        vol.fromJSON(
+            {
+                [`${process.cwd()}/snacks/easy/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-2/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-2/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-2/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-3/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-3/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-3/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/medium/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/medium/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/medium/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+            }
+        );
+        vol.mkdirSync(process.cwd(), { recursive: true });
+        await listAllSnacks('medium');
+
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+        expect(consoleLogSpy).toHaveBeenCalledWith('snack-1');
+    });
+
+    it('should log the message "no hard snacks availables"', async () => {
+
+        vol.fromJSON(
+            {
+                [`${process.cwd()}/snacks/easy/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-2/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-2/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-2/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-3/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-3/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-3/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/medium/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/medium/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/medium/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/hard`]: null,
+            }
+        );
+        vol.mkdirSync(process.cwd(), { recursive: true });
+        await listAllSnacks('hard');
+
+        expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+        expect(consoleLogSpy).toHaveBeenCalledWith('Currently there are no hard snacks availables');
+    });
+
+    it('should log the message "no hard snacks availables"', async () => {
+
+        vol.fromJSON(
+            {
+                [`${process.cwd()}/snacks/easy/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-2/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-2/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-2/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/easy/snack-3/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/easy/snack-3/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/easy/snack-3/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/medium/snack-1/snack.js`]: 'existingSnack',
+                [`${process.cwd()}/snacks/medium/snack-1/.solution/snack.js`]: 'existingSnackSolution',
+                [`${process.cwd()}/snacks/medium/snack-1/__tests__/snack.test.js`]: 'existingSnackTests',
+
+                [`${process.cwd()}/snacks/hard`]: null,
+            }
+        );
+        vol.mkdirSync(process.cwd(), { recursive: true });
+
+        await expect(() => listAllSnacks('non-existing-directory')).rejects.toThrowError(
+            /^ENOENT: no such file or directory/
+        );
+    });
+});

--- a/helpers/snack-explorer.js
+++ b/helpers/snack-explorer.js
@@ -1,0 +1,19 @@
+import fs from 'fs/promises';
+
+const listAllSnacks = async (difficulty) => {
+    try {
+        const snacks = await fs.readdir(`${process.cwd()}/snacks/${difficulty}`);
+
+        if (snacks.length > 0) {
+            snacks.forEach(snack => {
+                console.log(snack);
+            });
+        } else {
+            console.log(`Currently there are no ${difficulty} snacks availables`)
+        }
+    } catch (err) {
+        console.log(err);
+    }
+}
+
+export { listAllSnacks };

--- a/helpers/snack-explorer.js
+++ b/helpers/snack-explorer.js
@@ -12,7 +12,7 @@ const listAllSnacks = async (difficulty) => {
             console.log(`Currently there are no ${difficulty} snacks availables`)
         }
     } catch (err) {
-        console.log(err);
+        throw new Error(err.message);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 #! /usr/bin/env node
 
-import { Command, Option } from "commander";
-import { snackNameForTest, toKebabCase, difficultyExpand } from "./helpers/name-converter.js";
-import { createScaffolding } from "./helpers/snack-creator.js";
-import { exporter } from "./helpers/snack-export.js";
+import { Command, Option } from 'commander';
+import { snackNameForTest, toKebabCase, difficultyExpand } from './helpers/name-converter.js';
+import { createScaffolding } from './helpers/snack-creator.js';
+import { exporter } from './helpers/snack-export.js';
+import { listAllSnacks } from './helpers/snack-explorer.js'
 import chalk from 'chalk';
 const log = console.log;
 
 const program = new Command();
 
 program
+    .addOption(new Option('-a, --all', 'Get info for the available snacks'))
     .addOption(new Option('-i, --info-snack <name>', 'Get info for the selected snack'))
     .addOption(new Option('-c, --create-snack <name>', 'Create the scaffolding for a new snack'))
     .addOption(new Option('-d, --difficulty <difficulty>', 'Select snack difficulty').choices(['easy', 'e', 'medium', 'm', 'hard', 'h']).preset('easy'))
@@ -23,6 +25,11 @@ program
 program.parse(process.argv);
 
 const options = program.opts();
+if (options.all) {
+    const difficulty = difficultyExpand(options.difficulty ?? 'easy');
+    log(chalk.blue(`Getting a list of all ${difficulty} snacks...`));
+    await listAllSnacks(difficulty);
+}
 if (options.infoSnack) {
     const difficulty = options.difficulty ?? 'easy';
     const snackName = snackNameForTest(options.infoSnack, difficulty);

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ if (options.infoSnack) {
             log(chalk.green(`To test your solution for ${snackName} run the following command:\nnpm run test -- ${snackName}`));
         })
         .catch(error => {
-            log(chalk.red(`Cannot find a snack namend ${options.infoSnack} for the selected difficulty level (${difficulty})`));
+            log(chalk.red(`Cannot find a snack named ${options.infoSnack} for the selected difficulty level (${difficulty})`));
         });
 }
 if (options.createSnack) {

--- a/index.js
+++ b/index.js
@@ -55,5 +55,5 @@ if (options.createSnack) {
     createScaffolding(snackName, difficulty);
 }
 if (options.help) {
-    log(chalk.blue(`Read the ./README.md file to find how to start your training!`));
+    log(chalk.blue(`Check the ./README.md file to find how to start your training!`));
 }


### PR DESCRIPTION
The snack explorer helper can read and list all snack's name (the snack's dir) in the terminal.

The associated command is: `npx snack -a`.
Default snack difficulty level: easy.

The command can also be expanded with the difficulty level: `npx snack -a -d m` or `npx snack -a -d hard`